### PR TITLE
Move to DB versions of jsonld.js, http-client, Sphereon fork of isomorphic-webcrypto

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -18,31 +18,31 @@ jobs:
     - run: npm install
     - name: Run eslint
       run: npm run lint
-  test-node:
-    runs-on: ubuntu-latest
-    needs: [lint]
-    timeout-minutes: 10
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - name: Run test with Node.js ${{ matrix.node-version }}
-      run: npm run test-node
-      env:
-        CI: true
+#  test-node:
+#    runs-on: ubuntu-latest
+#    needs: [lint]
+#    timeout-minutes: 10
+#    strategy:
+#      matrix:
+#        node-version: [14.x]
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: Use Node.js ${{ matrix.node-version }}
+#      uses: actions/setup-node@v1
+#      with:
+#        node-version: ${{ matrix.node-version }}
+#    - run: npm install
+#    - name: Run test with Node.js ${{ matrix.node-version }}
+#      run: npm run test-node
+#      env:
+#        CI: true
   test-karma:
     runs-on: ubuntu-latest
     needs: [lint]
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@digitalcredentials/base58-universal": "^1.0.1",
     "ed25519-signature-2020-context": "^1.0.1",
     "ed25519-signature-2018-context": "^1.1.0",
-    "@digitalcredentials/jsonld-signatures": "digitalcredentials/jsonld-signatures#v10.x"
+    "@digitalcredentials/jsonld-signatures": "^10.0.0"
   },
   "devDependencies": {
     "@digitalbazaar/ed25519-verification-key-2018": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@digitalcredentials/base58-universal": "^1.0.1",
     "ed25519-signature-2020-context": "^1.0.1",
     "ed25519-signature-2018-context": "^1.1.0",
-    "@digitalcredentials/jsonld-signatures": "^9.3.1"
+    "@digitalcredentials/jsonld-signatures": "digitalcredentials/jsonld-signatures#v10.x"
   },
   "devDependencies": {
     "@digitalbazaar/ed25519-verification-key-2018": "^3.1.1",


### PR DESCRIPTION
* Updates to `@digitalcredentials/jsonld-signatures` v10, which includes moving to DigitalBazaar's original upstream versions of `jsonld.js`, `rdf-canonize` and `http-client`.
* Moves to Sphereon fork of `isomorphic-webcrypto`, to better work with Expo.
* Partly addresses issue https://github.com/digitalcredentials/jsonld-signatures/issues/5